### PR TITLE
implement command replies

### DIFF
--- a/assyst-common/src/util/filetype.rs
+++ b/assyst-common/src/util/filetype.rs
@@ -1,0 +1,73 @@
+use std::cmp::min;
+use std::ops::Range;
+
+#[derive(Debug, PartialEq)]
+pub enum Type {
+    GIF,
+    JPEG,
+    PNG,
+    WEBP,
+    MP4,
+    WEBM,
+}
+impl Type {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Type::GIF => "gif",
+            Type::JPEG => "jpeg",
+            Type::PNG => "png",
+            Type::WEBP => "webp",
+            Type::MP4 => "mp4",
+            Type::WEBM => "webm",
+        }
+    }
+    pub fn as_mime(&self) -> &'static str {
+        match self {
+            Type::GIF => "image/gif",
+            Type::JPEG => "image/jpeg",
+            Type::PNG => "image/png",
+            Type::WEBP => "image/webp",
+            Type::MP4 => "video/mp4",
+            Type::WEBM => "video/webm",
+        }
+    }
+    pub fn is_video(&self) -> bool {
+        match self {
+            Type::MP4 | Type::WEBM => true,
+            _ => false,
+        }
+    }
+}
+
+const WEBP: [u8; 4] = [87, 69, 66, 80];
+const MP4: [u8; 4] = [0x66, 0x74, 0x79, 0x70];
+
+fn bounded_range(start: usize, end: usize, len: usize) -> Range<usize> {
+    min(len, start)..min(len, end)
+}
+
+fn sig(that: &[u8], eq: &[u8]) -> bool {
+    that[0..std::cmp::min(eq.len(), that.len())].eq(eq)
+}
+
+fn check_webp(that: &[u8]) -> bool {
+    let bytes_offset_removed = &that[bounded_range(8, 12, that.len())];
+    sig(bytes_offset_removed, &WEBP)
+}
+
+fn check_mp4(that: &[u8]) -> bool {
+    let bytes_offset_removed = &that[bounded_range(4, 8, that.len())];
+    sig(bytes_offset_removed, &MP4)
+}
+
+pub fn get_sig(buf: &[u8]) -> Option<Type> {
+    match buf {
+        [71, 73, 70, ..] => Some(Type::GIF),
+        [255, 216, 255, ..] => Some(Type::JPEG),
+        [137, 80, 78, 71, 13, 10, 26, 10, ..] => Some(Type::PNG),
+        [0x1A, 0x45, 0xDF, 0xA3] => Some(Type::WEBM),
+        _ if check_webp(buf) => Some(Type::WEBP),
+        _ if check_mp4(buf) => Some(Type::MP4),
+        _ => None,
+    }
+}

--- a/assyst-common/src/util/mod.rs
+++ b/assyst-common/src/util/mod.rs
@@ -4,6 +4,7 @@ use tracing_subscriber::fmt::time::UtcTime;
 use tracing_subscriber::EnvFilter;
 
 pub mod discord;
+pub mod filetype;
 pub mod process;
 pub mod rate_tracker;
 pub mod regex;

--- a/assyst-core/Cargo.toml
+++ b/assyst-core/Cargo.toml
@@ -29,3 +29,4 @@ emoji = { git = "https://github.com/Jacherr/emoji-rs/", package = "emoji" }
 url = "2.5.0"
 futures-util = "0.3.30"
 serde_json = "1.0.113"
+moka = { version = "0.12.3", features = ["sync"] }

--- a/assyst-core/src/assyst.rs
+++ b/assyst-core/src/assyst.rs
@@ -1,4 +1,5 @@
 use crate::cache_handler::CacheHandler;
+use crate::replies::Replies;
 use crate::rest::patreon::Patron;
 use crate::task::Task;
 use assyst_common::config::CONFIG;
@@ -32,6 +33,8 @@ pub struct Assyst {
     pub tasks: Mutex<Vec<Task>>,
     /// The recommended number of shards for this instance.
     pub shard_count: u64,
+    /// Cached command replies
+    pub replies: Replies,
 }
 impl Assyst {
     pub async fn new() -> anyhow::Result<Assyst> {
@@ -58,6 +61,7 @@ impl Assyst {
             reqwest_client: reqwest::Client::new(),
             tasks: Mutex::new(vec![]),
             shard_count,
+            replies: Replies::new(),
         })
     }
 

--- a/assyst-core/src/command/messagebuilder.rs
+++ b/assyst-core/src/command/messagebuilder.rs
@@ -1,0 +1,68 @@
+use assyst_common::util::filetype::{get_sig, Type};
+
+use super::arguments::Image;
+
+#[derive(Debug)]
+pub struct Attachment {
+    pub name: Box<str>,
+    pub data: Vec<u8>,
+}
+
+impl From<Image> for Attachment {
+    fn from(value: Image) -> Self {
+        let ext = get_sig(&value.0).unwrap_or_else(|| Type::PNG).as_str();
+        Attachment {
+            name: format!("attachment.{ext}").into(),
+            data: value.0,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct MessageBuilder {
+    pub content: Option<String>,
+    pub attachment: Option<Attachment>,
+}
+
+impl From<&str> for MessageBuilder {
+    fn from(value: &str) -> Self {
+        Self {
+            content: Some(value.into()),
+            attachment: None,
+        }
+    }
+}
+impl From<String> for MessageBuilder {
+    fn from(value: String) -> Self {
+        Self {
+            content: Some(value),
+            attachment: None,
+        }
+    }
+}
+
+impl From<Attachment> for MessageBuilder {
+    fn from(value: Attachment) -> Self {
+        Self {
+            content: None,
+            attachment: Some(value),
+        }
+    }
+}
+
+impl From<Image> for MessageBuilder {
+    fn from(value: Image) -> Self {
+        Self {
+            content: None,
+            attachment: Some(value.into()),
+        }
+    }
+}
+impl From<(Image, &str)> for MessageBuilder {
+    fn from((image, text): (Image, &str)) -> Self {
+        Self {
+            attachment: Some(image.into()),
+            content: Some(text.into()),
+        }
+    }
+}

--- a/assyst-core/src/command/misc/mod.rs
+++ b/assyst-core/src/command/misc/mod.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::command::Availability;
 
@@ -14,11 +14,26 @@ use assyst_proc_macro::command;
     access = Availability::Public,
     cooldown = Duration::from_secs(2)
 )]
-pub fn remind(ctxt: CommandCtxt<'_>, when: Time, text: Rest) -> anyhow::Result<()> {
+pub async fn remind(_ctxt: CommandCtxt<'_>, _when: Time, _text: Rest) -> anyhow::Result<()> {
     Ok(())
 }
 
 #[command(description = "", cooldown = Duration::ZERO, access = Availability::Public)]
-pub fn e(ctxt: CommandCtxt<'_>, source: Image) -> anyhow::Result<()> {
+pub async fn e(ctxt: CommandCtxt<'_>, source: Image) -> anyhow::Result<()> {
+    ctxt.reply(source).await?;
+    Ok(())
+}
+
+#[command(description = "", cooldown = Duration::ZERO, access = Availability::Public)]
+pub async fn ping(ctxt: CommandCtxt<'_>) -> anyhow::Result<()> {
+    let processing_time = ctxt.data.processing_time_start.elapsed();
+    let ping_start = Instant::now();
+    ctxt.reply("ping!").await?;
+    let ping_elapsed = ping_start.elapsed();
+    ctxt.reply(format!(
+        "pong!\nprocessing time: {processing_time:?}\nresponse time: {ping_elapsed:?}"
+    ))
+    .await?;
+
     Ok(())
 }

--- a/assyst-core/src/command/registry.rs
+++ b/assyst-core/src/command/registry.rs
@@ -15,7 +15,7 @@ macro_rules! declare_commands {
     }
 }
 
-declare_commands!(misc::remind_command, misc::e_command);
+declare_commands!(misc::remind_command, misc::e_command, misc::ping_command);
 
 static COMMANDS: OnceLock<HashMap<&'static str, TCommand>> = OnceLock::new();
 

--- a/assyst-core/src/command/source.rs
+++ b/assyst-core/src/command/source.rs
@@ -1,0 +1,3 @@
+pub enum Source {
+    Gateway,
+}

--- a/assyst-core/src/gateway_handler/event_handlers/message_create.rs
+++ b/assyst-core/src/gateway_handler/event_handlers/message_create.rs
@@ -1,7 +1,10 @@
+use std::time::Instant;
+
 use assyst_common::err;
 use tracing::debug;
 use twilight_model::gateway::payload::incoming::MessageCreate;
 
+use crate::command::source::Source;
 use crate::command::{CommandCtxt, CommandData};
 use crate::gateway_handler::message_parser::error::{ErrorSeverity, GetErrorSeverity};
 use crate::gateway_handler::message_parser::parser::parse_message_into_command;
@@ -15,12 +18,15 @@ pub async fn handle(assyst: ThreadSafeAssyst, MessageCreate(message): MessageCre
     match parse_message_into_command(assyst.clone(), &message).await {
         Ok(Some((cmd, args))) => {
             let data = CommandData {
+                message_id: message.id.get(),
+                source: Source::Gateway,
                 assyst: &assyst,
                 attachment: message.attachments.first(),
                 referenced_message: message.referenced_message.as_deref(),
                 sticker: message.sticker_items.first(),
                 channel_id: message.channel_id.get(),
                 embed: message.embeds.first(),
+                processing_time_start: Instant::now(),
             };
             let ctxt = CommandCtxt::new(args, &data);
 

--- a/assyst-core/src/gateway_handler/event_handlers/message_delete.rs
+++ b/assyst-core/src/gateway_handler/event_handlers/message_delete.rs
@@ -1,10 +1,23 @@
+use assyst_common::err;
 use twilight_model::gateway::payload::incoming::MessageDelete;
+use twilight_model::id::Id;
+
+use crate::assyst::ThreadSafeAssyst;
+use crate::replies::ReplyState;
 
 /// Handle a [MessageDelete] event received from the Discord gateway.
 ///
 /// This function checks if the deleted message was one that invoked an Assyst command.
 /// If it was, then Assyst will attempt to delete the response to that command, to prevent any
 /// "dangling responses".
-pub fn handle(event: MessageDelete) {
-    // fetch the bot's response for this message if it exists, and if it does, delete it
+pub async fn handle(assyst: ThreadSafeAssyst, message: MessageDelete) {
+    if let Some(reply) = assyst.replies.get(message.id.get())
+        && let ReplyState::InUse(reply) = reply.state
+    {
+        _ = assyst
+            .http_client
+            .delete_message(message.channel_id, Id::new(reply.message_id))
+            .await
+            .inspect_err(|e| err!("{e}"));
+    }
 }

--- a/assyst-core/src/gateway_handler/mod.rs
+++ b/assyst-core/src/gateway_handler/mod.rs
@@ -5,6 +5,7 @@ use self::incoming_event::IncomingEvent;
 pub mod event_handlers;
 pub mod incoming_event;
 pub mod message_parser;
+pub mod reply;
 
 /// Checks the enum variant of this IncomingEvent and calls the appropriate handler function
 /// for further processing.
@@ -20,7 +21,7 @@ pub async fn handle_raw_event(context: ThreadSafeAssyst, event: IncomingEvent) {
             event_handlers::message_update::handle(context, event).await;
         },
         IncomingEvent::MessageDelete(event) => {
-            event_handlers::message_delete::handle(event);
+            event_handlers::message_delete::handle(context, event).await;
         },
         IncomingEvent::GuildCreate(event) => {
             event_handlers::guild_create::handle(context, event).await;

--- a/assyst-core/src/gateway_handler/reply.rs
+++ b/assyst-core/src/gateway_handler/reply.rs
@@ -1,0 +1,105 @@
+use std::time::Instant;
+
+use twilight_model::channel::message::AllowedMentions;
+use twilight_model::http::attachment::Attachment as TwilightAttachment;
+use twilight_model::id::Id;
+
+use crate::command::messagebuilder::MessageBuilder;
+use crate::command::CommandCtxt;
+use crate::replies::{Reply, ReplyInUse, ReplyState};
+
+/// Trims a `String` in-place such that it fits in Discord's 2000 character message limit.
+fn trim_content_fits(content: &mut String) {
+    if let Some((truncated_byte_index, _)) = content.char_indices().nth(2000) {
+        // If the content length exceeds 2000 characters, truncate it at the 2000th characters' byte index
+        content.truncate(truncated_byte_index);
+    }
+}
+
+pub async fn edit(ctxt: &CommandCtxt<'_>, mut builder: MessageBuilder, reply: ReplyInUse) -> anyhow::Result<()> {
+    // If either the already-sent reply or the builder has an
+    // attachment, we need to delete the reply and send another one, since an attachment can't be
+    // edited.
+    if builder.attachment.is_some() || reply.has_attachments {
+        ctxt.data
+            .assyst
+            .http_client
+            .delete_message(Id::new(ctxt.data.channel_id), Id::new(reply.message_id))
+            .await?;
+
+        return create_message(ctxt, builder).await;
+    }
+
+    let allowed_mentions = AllowedMentions::default();
+
+    let mut message = ctxt
+        .data
+        .assyst
+        .http_client
+        .update_message(Id::new(ctxt.data.channel_id), Id::new(reply.message_id))
+        .allowed_mentions(Some(&allowed_mentions));
+
+    if let Some(content) = &mut builder.content {
+        trim_content_fits(content);
+        message = message.content(Some(content))?;
+    }
+
+    message.await?;
+    Ok(())
+}
+
+async fn create_message(ctxt: &CommandCtxt<'_>, mut builder: MessageBuilder) -> anyhow::Result<()> {
+    let allowed_mentions = AllowedMentions::default();
+
+    let mut message = ctxt
+        .data
+        .assyst
+        .http_client
+        .create_message(Id::new(ctxt.data.channel_id))
+        .allowed_mentions(Some(&allowed_mentions));
+
+    if let Some(content) = &mut builder.content {
+        trim_content_fits(content);
+        message = message.content(content)?;
+    }
+
+    let attachments;
+    if let Some(attachment) = builder.attachment {
+        attachments = [TwilightAttachment::from_bytes(
+            attachment.name.into(),
+            attachment.data,
+            0,
+        )];
+
+        message = message.attachments(&attachments)?;
+    }
+
+    let reply = message.await?.model().await?;
+    ctxt.data.assyst.replies.insert(
+        ctxt.data.message_id,
+        Reply {
+            state: ReplyState::InUse(ReplyInUse {
+                message_id: reply.id.get(),
+                has_attachments: !reply.attachments.is_empty(),
+            }),
+            created: Instant::now(),
+        },
+    );
+
+    Ok(())
+}
+
+pub async fn reply(ctxt: &CommandCtxt<'_>, builder: MessageBuilder) -> anyhow::Result<()> {
+    let reply_in_use = ctxt
+        .data
+        .assyst
+        .replies
+        .get(ctxt.data.message_id)
+        .and_then(|r| r.in_use());
+
+    if let Some(reply_in_use) = reply_in_use {
+        edit(ctxt, builder, reply_in_use).await
+    } else {
+        create_message(ctxt, builder).await
+    }
+}

--- a/assyst-core/src/replies.rs
+++ b/assyst-core/src/replies.rs
@@ -1,0 +1,58 @@
+use std::time::{Duration, Instant};
+
+use moka::sync::Cache;
+
+#[derive(Copy, Clone, Debug)]
+pub struct ReplyInUse {
+    /// The message ID of this reply
+    pub message_id: u64,
+    /// Whether the reply has any attachments.
+    pub has_attachments: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum ReplyState {
+    Processing,
+    InUse(ReplyInUse),
+}
+
+#[derive(Debug, Clone)]
+pub struct Reply {
+    pub state: ReplyState,
+    pub created: Instant,
+}
+
+impl Reply {
+    pub fn in_use(&self) -> Option<ReplyInUse> {
+        if let ReplyState::InUse(reply) = self.state {
+            Some(reply)
+        } else {
+            None
+        }
+    }
+}
+
+pub struct Replies(Cache<u64, Reply>);
+
+impl Replies {
+    pub fn new() -> Self {
+        Self(
+            Cache::builder()
+                .max_capacity(1000)
+                .time_to_idle(Duration::from_secs(60 * 5))
+                .build(),
+        )
+    }
+
+    pub fn insert(&self, id: u64, reply: Reply) {
+        self.0.insert(id, reply);
+    }
+
+    pub fn remove(&self, id: u64) -> Option<Reply> {
+        self.0.remove(&id)
+    }
+
+    pub fn get(&self, id: u64) -> Option<Reply> {
+        self.0.get(&id)
+    }
+}


### PR DESCRIPTION
It's now possible to reply to commands, with the same behavior as the old bot.

Other changes/additions:
- replies are stored in `Assyst::replies` (wrapped in a special `Replies` struct to make it easy to swap out the backing map)
- adds `CommandCtxt::reply`, which takes in an `impl Into<MessageBuilder>`, making it possible to:
  - pass `&str` for a text-only response
  - pass `Attachment` for files
  - pass `Image` for convenience (detects the image type)
  - pass `(Image, &str)` for text+image