### PR TITLE
add way too many updates

### DIFF
--- a/assyst-common/src/ansi.rs
+++ b/assyst-common/src/ansi.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 pub trait Ansi {
     fn bold(&self) -> String;
     fn italic(&self) -> String;
@@ -37,7 +39,10 @@ pub trait Ansi {
     fn bg_bright_white(&self) -> String;
 }
 
-impl Ansi for str {
+impl<T> Ansi for T
+where
+    T: Display,
+{
     fn bold(&self) -> String {
         format!("\x1b[1m{}\x1b[22m", self)
     }

--- a/assyst-common/src/config/mod.rs
+++ b/assyst-common/src/config/mod.rs
@@ -1,6 +1,6 @@
 pub mod config;
 
-static CONFIG_LOCATION: &str = "../config.toml";
+static CONFIG_LOCATION: &str = "./config.toml";
 
 use lazy_static::lazy_static;
 use toml::from_str;

--- a/assyst-common/src/lib.rs
+++ b/assyst-common/src/lib.rs
@@ -2,6 +2,7 @@ pub mod ansi;
 pub mod cache;
 pub mod config;
 pub mod macros;
+pub mod markdown;
 pub mod pipe;
 pub mod prometheus;
 pub mod util;

--- a/assyst-common/src/markdown.rs
+++ b/assyst-common/src/markdown.rs
@@ -1,0 +1,147 @@
+use std::fmt::Display;
+
+use regex::{Captures, Regex};
+
+pub trait Markdown {
+    fn escape_italics(&self) -> String;
+    fn escape_bold(&self) -> String;
+    fn escape_codestring(&self) -> String;
+    fn escape_codeblock(&self, language: impl Display) -> String;
+    fn escape_spoiler(&self) -> String;
+    fn escape_strikethrough(&self) -> String;
+    fn escape_underline(&self) -> String;
+
+    fn italics(&self) -> String;
+    fn bold(&self) -> String;
+    fn codestring(&self) -> String;
+    fn codeblock(&self, language: impl Display) -> String;
+    fn spoiler(&self) -> String;
+    fn strikethrough(&self) -> String;
+    fn underline(&self) -> String;
+    fn url(&self, url: impl Display, comment: Option<impl Display>) -> String;
+    fn timestamp(seconds: usize, style: TimestampStyle) -> String {
+        format!("<t:{seconds}:{style}>")
+    }
+}
+
+pub enum TimestampStyle {
+    FullLong,
+    FullShort,
+    DateLong,
+    DateShort,
+    TimeLong,
+    TimeShort,
+    Relative,
+}
+
+impl Display for TimestampStyle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::FullLong => "F",
+                Self::FullShort => "f",
+                Self::DateLong => "D",
+                Self::DateShort => "d",
+                Self::TimeLong => "T",
+                Self::TimeShort => "t",
+                Self::Relative => "R",
+            }
+        )
+    }
+}
+
+fn cut(t: impl Display, to: usize) -> String {
+    t.to_string().chars().take(to).collect::<String>()
+}
+
+impl<T> Markdown for T
+where
+    T: Display,
+{
+    fn escape_italics(&self) -> String {
+        Regex::new(r"_|\*")
+            .unwrap()
+            .replace_all(&cut(self, 1998), |x: &Captures| {
+                format!("\\{}", x.get(0).unwrap().as_str())
+            })
+            .into_owned()
+    }
+    fn escape_bold(&self) -> String {
+        Regex::new(r"\*\*")
+            .unwrap()
+            .replace_all(&cut(self, 1998), r"\*\*")
+            .into_owned()
+    }
+    fn escape_codestring(&self) -> String {
+        Regex::new(r"`")
+            .unwrap()
+            .replace_all(&cut(self, 1998), r"'")
+            .into_owned()
+    }
+    fn escape_codeblock(&self, language: impl Display) -> String {
+        Regex::new(r"```")
+            .unwrap()
+            .replace_all(&cut(self, 1988 - language.to_string().len()), "`\u{200b}`\u{200b}`")
+            .into_owned()
+    }
+
+    fn escape_spoiler(&self) -> String {
+        Regex::new(r"__")
+            .unwrap()
+            .replace_all(&cut(self, 1996), r"\|\|")
+            .into_owned()
+    }
+    fn escape_strikethrough(&self) -> String {
+        Regex::new(r"~~")
+            .unwrap()
+            .replace_all(&cut(self, 1996), r"\~\~")
+            .into_owned()
+    }
+    fn escape_underline(&self) -> String {
+        Regex::new(r"\|\|")
+            .unwrap()
+            .replace_all(&cut(self, 1996), r"\_\_")
+            .into_owned()
+    }
+
+    fn italics(&self) -> String {
+        format!("_{}_", self.escape_italics())
+    }
+
+    fn bold(&self) -> String {
+        format!("**{}**", self.escape_bold())
+    }
+
+    fn codestring(&self) -> String {
+        format!("`{}`", self.escape_codestring())
+    }
+
+    fn codeblock(&self, language: impl Display) -> String {
+        let t = self.escape_codeblock(&language);
+        format!("```{language}\n{}\n```", t)
+    }
+
+    fn spoiler(&self) -> String {
+        format!("||{}||", self.escape_italics())
+    }
+
+    fn strikethrough(&self) -> String {
+        format!("~~{}~~", self.escape_italics())
+    }
+
+    fn underline(&self) -> String {
+        format!("__{}__", self.escape_italics())
+    }
+
+    fn url(&self, url: impl Display, comment: Option<impl Display>) -> String {
+        format!(
+            "[{self}]({url}{})",
+            match comment {
+                Some(c) => format!(" '{c}'"),
+                None => "".to_string(),
+            }
+        )
+    }
+}

--- a/assyst-core/src/command/arguments.rs
+++ b/assyst-core/src/command/arguments.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use assyst_common::util::discord::get_avatar_url;
 use assyst_common::util::{parse_to_millis, regex};
 use serde::Deserialize;
@@ -234,6 +236,12 @@ impl ImageUrl {
         }
 
         Err(TagParseError::NoImageInHistory)
+    }
+}
+
+impl Display for ImageUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/assyst-core/src/command/misc/mod.rs
+++ b/assyst-core/src/command/misc/mod.rs
@@ -1,10 +1,14 @@
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use crate::command::Availability;
 
-use super::arguments::{Image, Rest, Time};
-use super::CommandCtxt;
+use super::arguments::{self, Image, ImageUrl, Rest, Time, Word};
+use super::registry::get_or_init_commands;
+use super::{Category, Command, CommandCtxt};
 
+use assyst_common::ansi::Ansi;
+use assyst_common::markdown::Markdown;
 use assyst_proc_macro::command;
 
 #[command(
@@ -12,19 +16,27 @@ use assyst_proc_macro::command;
     aliases = ["reminder"],
     description = "get reminders or set a reminder, time format is xdyhzm (check examples)",
     access = Availability::Public,
-    cooldown = Duration::from_secs(2)
+    cooldown = Duration::from_secs(2),
+    category = Category::Misc,
+    examples = [],
 )]
 pub async fn remind(_ctxt: CommandCtxt<'_>, _when: Time, _text: Rest) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[command(description = "", cooldown = Duration::ZERO, access = Availability::Public)]
+#[command(description = "enlarges an image", cooldown = Duration::ZERO, access = Availability::Public, category = Category::Misc)]
 pub async fn e(ctxt: CommandCtxt<'_>, source: Image) -> anyhow::Result<()> {
     ctxt.reply(source).await?;
     Ok(())
 }
 
-#[command(description = "", cooldown = Duration::ZERO, access = Availability::Public)]
+#[command(description = "returns the URL of any captured media", cooldown = Duration::ZERO, access = Availability::Public, category = Category::Misc)]
+pub async fn url(ctxt: CommandCtxt<'_>, source: ImageUrl) -> anyhow::Result<()> {
+    ctxt.reply(format!("\u{200b}{source}")).await?;
+    Ok(())
+}
+
+#[command(description = "ping the discord api", cooldown = Duration::ZERO, access = Availability::Public, category = Category::Misc)]
 pub async fn ping(ctxt: CommandCtxt<'_>) -> anyhow::Result<()> {
     let processing_time = ctxt.data.processing_time_start.elapsed();
     let ping_start = Instant::now();
@@ -34,6 +46,120 @@ pub async fn ping(ctxt: CommandCtxt<'_>) -> anyhow::Result<()> {
         "pong!\nprocessing time: {processing_time:?}\nresponse time: {ping_elapsed:?}"
     ))
     .await?;
+
+    Ok(())
+}
+
+#[command(description = "get command help", cooldown = Duration::ZERO, access = Availability::Public, category = Category::Misc)]
+pub async fn help(ctxt: CommandCtxt<'_>, label: Option<Word>) -> anyhow::Result<()> {
+    let cmds = get_or_init_commands();
+
+    // group commands by their category
+    let mut groups: HashMap<Category, Vec<_>> = HashMap::new();
+    for data in cmds.values() {
+        let c = &data.metadata().category;
+        groups.entry(c.clone()).or_default();
+        let entry = groups.get_mut(&data.metadata().category);
+
+        if let Some(l) = entry {
+            if !l
+                .iter()
+                .any(|x: &&&(dyn Command + Send + Sync)| x.metadata().name == data.metadata().name)
+            {
+                l.push(data);
+            }
+        }
+    }
+
+    // if we have some argument
+    if let Some(l) = label {
+        let tx = l.0.to_lowercase();
+
+        // if said argument is a command
+        if let Some(cmd) = cmds.get(&*tx) {
+            let meta = &cmd.metadata();
+            ctxt.reply(
+                format!(
+                    "{}{}{}\n{}\n\n{}\n{} {} {}\n{} {}\n",
+                    Ansi::underline(&meta.name.fg_yellow()),
+                    ":".fg_yellow(),
+                    "\x1b[0m", // dude fuck discord
+                    meta.description,
+                    if !meta.aliases.is_empty() {
+                        format!("{} {}", " Aliases:".fg_yellow(), meta.aliases.join(", "))
+                    } else {
+                        "[none]".fg_black()
+                    },
+                    "Cooldown:".fg_yellow(),
+                    meta.cooldown.as_secs(),
+                    "seconds",
+                    "  Access:".fg_yellow(),
+                    meta.access
+                )
+                .trim()
+                .codeblock("ansi"),
+            )
+            .await?;
+            // otherwise, its either irrelevant or a category
+        } else {
+            let g: Category = tx.clone().into();
+
+            // if its a category
+            if let Category::None(_) = g {
+                ctxt.reply(format!(
+                    "{} No command or group named {} found.",
+                    emoji::symbols::warning::WARNING.glyph,
+                    tx.codestring()
+                ))
+                .await?;
+            // irrelevant
+            } else {
+                let mut txt = String::new();
+                txt += &Ansi::underline(&format!("{g}:").fg_yellow());
+                txt += "\x1b[0m"; // again
+                let l = groups.get(&g);
+
+                if let Some(list) = l {
+                    for i in list {
+                        txt += &format!("\n\t{}: {}", i.metadata().name, i.metadata().description.fg_black())
+                    }
+                } else {
+                    txt += &"\n\t[no commands]".fg_black()
+                }
+
+                ctxt.reply(txt.codeblock("ansi")).await?;
+            }
+        }
+    } else {
+        let mut msg = String::new();
+        for (group, list) in groups {
+            msg += &format!(
+                "{}{} {}",
+                group.fg_yellow(),
+                ':'.fg_yellow(),
+                list.iter().map(|x| x.metadata().name).collect::<Vec<_>>().join(", ")
+            );
+        }
+
+        msg = msg.codeblock("ansi");
+
+        msg += &format!(
+            "\nDo {} for more info on a command.\n\n",
+            "-help [command]".codestring()
+        );
+
+        msg += &format!(
+            "{} | {} | {}",
+            "Invite".url("<https://jacher.io/assyst>", Some("Invite link for Assyst.")),
+            "Support Server".url(
+                "<https://discord.gg/brmtnpxbtg>",
+                Some("Invite link for the Assyst Support Discord Server.")
+            ),
+            "top.gg".url("<https://vote.jacher.io/topgg>", Some("top.gg vote link for Assyst."))
+        );
+
+        ctxt.reply(msg).await?;
+    }
 
     Ok(())
 }

--- a/assyst-core/src/command/mod.rs
+++ b/assyst-core/src/command/mod.rs
@@ -26,6 +26,7 @@
 //!   entry point (and the only relevant for the outside) is [`registry::find_command_by_name`],
 //!   which does the mapping mentioned above.
 
+use std::fmt::Display;
 use std::future::Future;
 use std::str::SplitAsciiWhitespace;
 use std::time::{Duration, Instant};
@@ -49,6 +50,7 @@ pub mod registry;
 pub mod source;
 
 /// Defines who can use a command in a server.
+#[derive(Clone, Copy, Debug)]
 pub enum Availability {
     /// Anyone can use this command, subject to blacklisting and whitelisting configuration.
     Public,
@@ -58,12 +60,65 @@ pub enum Availability {
     Dev,
 }
 
+impl Display for Availability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Public => "Public",
+                Self::ServerManagers => "Server Managers",
+                Self::Dev => "Private",
+            }
+        )
+    }
+}
+
 pub struct CommandMetadata {
     pub name: &'static str,
     pub aliases: &'static [&'static str],
     pub description: &'static str,
     pub cooldown: Duration,
     pub access: Availability,
+    pub category: Category,
+    pub examples: &'static [&'static str],
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum Category {
+    Fun,
+    Makesweet,
+    Wsi,
+    Misc,
+    None(String),
+}
+
+impl Display for Category {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Fun => "fun",
+                Self::Makesweet => "makesweet",
+                Self::Wsi => "wsi",
+                Self::Misc => "misc",
+                Self::None(t) => &**t,
+            }
+        )
+    }
+}
+
+impl From<String> for Category {
+    fn from(v: String) -> Category {
+        match &*v {
+            "fun" => Category::Fun,
+            "misc" => Category::Misc,
+            "wsi" => Category::Wsi,
+            "makesweet" => Category::Makesweet,
+            t => Category::None(t.to_string()),
+        }
+    }
 }
 
 /// A command that can be executed.

--- a/assyst-core/src/command/registry.rs
+++ b/assyst-core/src/command/registry.rs
@@ -15,11 +15,17 @@ macro_rules! declare_commands {
     }
 }
 
-declare_commands!(misc::remind_command, misc::e_command, misc::ping_command);
+declare_commands!(
+    misc::remind_command,
+    misc::e_command,
+    misc::ping_command,
+    misc::url_command,
+    misc::help_command
+);
 
 static COMMANDS: OnceLock<HashMap<&'static str, TCommand>> = OnceLock::new();
 
-fn get_or_init_commands() -> &'static HashMap<&'static str, TCommand> {
+pub fn get_or_init_commands() -> &'static HashMap<&'static str, TCommand> {
     COMMANDS.get_or_init(|| {
         let mut map = HashMap::new();
 

--- a/assyst-core/src/main.rs
+++ b/assyst-core/src/main.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::assyst::{Assyst, ThreadSafeAssyst};
+use crate::task::tasks::get_patrons::get_patrons;
 use crate::task::tasks::top_gg_stats::post_top_gg_stats;
 use crate::task::Task;
 use assyst_common::config::config::LoggingWebhook;

--- a/assyst-proc-macro/src/lib.rs
+++ b/assyst-proc-macro/src/lib.rs
@@ -103,6 +103,8 @@ pub fn command(attrs: TokenStream, func: TokenStream) -> TokenStream {
     let description = fields.remove("description").expect("missing description");
     let cooldown = fields.remove("cooldown").expect("missing cooldown");
     let access = fields.remove("access").expect("missing access");
+    let category = fields.remove("category").expect("missing category");
+    let examples = fields.remove("examples").unwrap_or(empty_array_expr());
 
     let following = quote::quote! {
         pub struct #struct_name;
@@ -115,7 +117,9 @@ pub fn command(attrs: TokenStream, func: TokenStream) -> TokenStream {
                     cooldown: #cooldown,
                     access: #access,
                     name: #name,
-                    aliases: &#aliases
+                    aliases: &#aliases,
+                    category: #category,
+                    examples: &#examples,
                 };
                 &META
             }


### PR DESCRIPTION
- implement `help` and `url` commands
- add `category` and `examples` property to `Command`
- add utility trait for Markdown formatting
- generalize `Ansi` from `str` to `T: Display`
- add `Display` implementation for `ImageUrl`, returning the URL itself