### PR TITLE
implement subcommands

### DIFF
--- a/assyst-core/Cargo.toml
+++ b/assyst-core/Cargo.toml
@@ -33,3 +33,4 @@ moka = { version = "0.12.3", features = ["sync"] }
 human_bytes = { version = "0.4", default-features = false }
 shared = { git = "https://github.com/jacherr/wsi-shared" }
 bincode = "1.3.3"
+paste = "1.0.14"

--- a/assyst-core/src/command/group.rs
+++ b/assyst-core/src/command/group.rs
@@ -1,0 +1,108 @@
+use super::errors::{ExecutionError, TagParseError};
+use super::{CommandCtxt, TCommand};
+
+// Helper macro that provides defaults
+// cfg_attr is needed because of https://github.com/rust-lang/rust/issues/74087
+#[cfg_attr(rustfmt, rustfmt::skip)]
+#[doc(hidden)] // don't use this anywhere except for inside of the `define_commandgroup` macro
+#[macro_export]
+macro_rules! defaults {
+    (access $x:expr) => { $x };
+    (access) => { crate::command::Availability::Public };
+    (aliases $x:expr) => { $x };
+    (aliases) => { &[] };
+    (cooldown $x:expr) => { $x };
+    (cooldown) => { std::time::Duration::ZERO };
+    (examples $x:expr) => { $x };
+    (examples) => { &[] };
+    (age_restricted $x:expr) => { $x };
+    (age_restricted) => { false };
+    (usage $x:expr) => { $x };
+    (usage) => { "" };
+    (send_processing $x:expr) => { $x };
+    (send_processing) => { false };
+}
+
+#[macro_export]
+macro_rules! define_commandgroup {
+    (
+        name: $groupname:ident,
+        $(access: $access:expr,)?
+        category: $category:expr,
+        $(aliases: $aliases:expr,)?
+        $(cooldown: $cooldown:expr,)?
+        description: $description:expr,
+        $(examples: $examples:expr,)?
+        $(usage: $usage:expr,)?
+        $(send_processing: $send_processing:expr,)?
+        $(age_restricted: $age_restricted:expr,)?
+        commands: [
+            $(
+                $subcommand:literal => $commandfn:expr
+            ),*
+        ]
+    ) => {
+        paste::paste! {
+            #[allow(non_camel_case_types)]
+            pub struct [<$groupname _command>];
+
+            impl [<$groupname _command>] {
+                const SUBCOMMANDS: &'static [(&'static str, crate::command::TCommand)] = &[
+                    $(
+                        ($subcommand, &[<$commandfn _command>])
+                    ),*
+                ];
+            }
+
+            #[::async_trait::async_trait]
+            impl crate::command::Command for [<$groupname _command>] {
+                fn metadata(&self) -> &'static crate::command::CommandMetadata {
+                    // TODO: use options in metadata instead of things like empty &str
+
+                    static META: crate::command::CommandMetadata = crate::command::CommandMetadata {
+                        access: $crate::defaults!(access $($access)?),
+                        category: $category,
+                        aliases: $crate::defaults!(aliases $(&$aliases)?),
+                        cooldown: $crate::defaults!(cooldown $($cooldown)?),
+                        description: $description,
+                        examples: $crate::defaults!(examples $(&$examples)?),
+                        name: stringify!($groupname),
+                        age_restricted: $crate::defaults!(age_restricted $($age_restricted)?),
+                        usage: $crate::defaults!(usage $($usage)?),
+                        send_processing: $crate::defaults!(send_processing $($send_processing)?)
+                    };
+                    &META
+                }
+
+                fn subcommand(&self, sub: &str) -> Option<crate::command::TCommand> {
+                    crate::command::group::find_subcommand(sub, Self::SUBCOMMANDS)
+                }
+
+                async fn execute(&self, ctxt: CommandCtxt<'_>) -> Result<(), crate::command::ExecutionError> {
+                    crate::command::group::execute_subcommand(ctxt, Self::SUBCOMMANDS).await
+                }
+            }
+        }
+    };
+}
+
+pub fn find_subcommand(sub: &str, cmds: &[(&str, TCommand)]) -> Option<TCommand> {
+    cmds.iter().find(|(k, _)| *k == sub).map(|(_, v)| v).copied()
+}
+
+/// Tries to execute a subcommand, by taking the next word from the arguments and looking for it in
+/// `commands`
+pub async fn execute_subcommand(
+    mut ctxt: CommandCtxt<'_>,
+    commands: &[(&str, TCommand)],
+) -> Result<(), ExecutionError> {
+    let subcommand = ctxt.next_word().map_err(|err| ExecutionError::Parse(err.into()))?;
+
+    let command =
+        find_subcommand(subcommand, commands).ok_or(ExecutionError::Parse(TagParseError::InvalidSubcommand))?;
+
+    // TODO: subcommands might want to be commands themselves, e.g. `-t <tagname>` does not have a valid
+    // subcommand, but still needs to be handled
+
+    command.execute(ctxt).await
+}

--- a/assyst-core/src/command/misc/tag.rs
+++ b/assyst-core/src/command/misc/tag.rs
@@ -1,0 +1,26 @@
+use std::time::Duration;
+
+use assyst_proc_macro::command;
+
+use crate::command::{Availability, Category};
+use crate::define_commandgroup;
+
+use super::{CommandCtxt, Rest, Word};
+
+#[command(description = "creates a tag", cooldown = Duration::from_secs(2), access = Availability::Public, category = Category::Misc, usage = "<name> <contents>")]
+pub async fn create(ctxt: CommandCtxt<'_>, Word(name): Word, Rest(contents): Rest) -> anyhow::Result<()> {
+    ctxt.reply(format!("create tag, name={name}, contents={contents}"))
+        .await?;
+    Ok(())
+}
+
+define_commandgroup! {
+    name: tag,
+    access: Availability::Public,
+    category: Category::Misc,
+    description: "tags",
+    usage: "<create>",
+    commands: [
+        "create" => create
+    ]
+}

--- a/assyst-core/src/command/registry.rs
+++ b/assyst-core/src/command/registry.rs
@@ -22,19 +22,21 @@ declare_commands!(
     misc::url_command,
     misc::help_command,
     misc::stats_command,
-    wsi::caption_command
+    wsi::caption_command,
+    misc::tag::tag_command
 );
 
 static COMMANDS: OnceLock<HashMap<&'static str, TCommand>> = OnceLock::new();
 
+/// Prefer [`find_command_by_name`] where possible.
 pub fn get_or_init_commands() -> &'static HashMap<&'static str, TCommand> {
     COMMANDS.get_or_init(|| {
         let mut map = HashMap::new();
 
         for &command in RAW_COMMANDS {
             let &CommandMetadata { name, aliases, .. } = command.metadata();
-            info!("Registering command {} (aliases={:?})", name, aliases);
             map.insert(name, command);
+            info!("Registering command {} (aliases={:?})", name, aliases);
             for alias in aliases {
                 map.insert(alias, command);
             }

--- a/assyst-core/src/gateway_handler/event_handlers/guild_create.rs
+++ b/assyst-core/src/gateway_handler/event_handlers/guild_create.rs
@@ -12,7 +12,7 @@ pub async fn handle(assyst: ThreadSafeAssyst, event: GuildCreate) {
     let should_handle = match assyst.persistent_cache_handler.handle_guild_create_event(event).await {
         Ok(s) => s,
         Err(e) => {
-            err!("assyst-cache failed to handle GUILD_CREATE event: {}", e.to_string());
+            err!("assyst-cache failed to handle GUILD_CREATE event: {}", e);
             return;
         },
     };

--- a/assyst-core/src/gateway_handler/event_handlers/message_create.rs
+++ b/assyst-core/src/gateway_handler/event_handlers/message_create.rs
@@ -1,4 +1,3 @@
-use std::fmt::format;
 use std::time::Instant;
 
 use assyst_common::err;
@@ -11,8 +10,6 @@ use crate::command::{CommandCtxt, CommandData};
 use crate::gateway_handler::message_parser::error::{ErrorSeverity, GetErrorSeverity};
 use crate::gateway_handler::message_parser::parser::parse_message_into_command;
 use crate::ThreadSafeAssyst;
-
-use super::ctxt_exec;
 
 /// Handle a [MessageCreate] event received from the Discord gateway.
 ///
@@ -37,7 +34,7 @@ pub async fn handle(assyst: ThreadSafeAssyst, MessageCreate(message): MessageCre
             };
             let ctxt = CommandCtxt::new(args, &data);
 
-            if let Err(err) = ctxt_exec(&ctxt, cmd).await {
+            if let Err(err) = cmd.execute(ctxt.clone()).await {
                 match err.get_severity() {
                     ErrorSeverity::Low => debug!("{err:?}"),
                     ErrorSeverity::High => match err {

--- a/assyst-core/src/gateway_handler/event_handlers/message_update.rs
+++ b/assyst-core/src/gateway_handler/event_handlers/message_update.rs
@@ -16,8 +16,6 @@ use crate::gateway_handler::message_parser::parser::parse_message_into_command;
 use crate::replies::ReplyState;
 use crate::ThreadSafeAssyst;
 
-use super::ctxt_exec;
-
 /// Handle a [MessageUpdate] event sent from the Discord gateway.
 ///
 /// Message updates are used to check the following:
@@ -46,7 +44,7 @@ pub async fn handle(assyst: ThreadSafeAssyst, event: MessageUpdate) {
                     };
                     let ctxt = CommandCtxt::new(args, &data);
 
-                    if let Err(err) = ctxt_exec(&ctxt, cmd).await {
+                    if let Err(err) = cmd.execute(ctxt.clone()).await {
                         match err.get_severity() {
                             ErrorSeverity::Low => debug!("{err:?}"),
                             ErrorSeverity::High => match err {

--- a/assyst-core/src/gateway_handler/event_handlers/mod.rs
+++ b/assyst-core/src/gateway_handler/event_handlers/mod.rs
@@ -1,34 +1,6 @@
-use crate::command::errors::{ExecutionError, TagParseError};
-use crate::command::{Command, CommandCtxt};
-
 pub mod guild_create;
 pub mod guild_delete;
 pub mod message_create;
 pub mod message_delete;
 pub mod message_update;
 pub mod ready;
-
-pub(super) async fn ctxt_exec(ctxt: &CommandCtxt<'_>, cmd: &(dyn Command + Send + Sync)) -> Result<(), ExecutionError> {
-    if cmd.metadata().age_restricted {
-        let channel_age_restricted = ctxt
-            .assyst()
-            .rest_cache_handler
-            .channel_is_age_restricted(ctxt.data.channel_id)
-            .await
-            .unwrap_or(false);
-
-        if !channel_age_restricted {
-            return Err(ExecutionError::Parse(TagParseError::IllegalAgeRestrictedCommand));
-        };
-    };
-
-    if cmd.metadata().send_processing {
-        if let Err(e) = ctxt.reply("Processing...").await {
-            Err(ExecutionError::Command(e))
-        } else {
-            cmd.execute(ctxt.clone()).await
-        }
-    } else {
-        cmd.execute(ctxt.clone()).await
-    }
-}

--- a/assyst-core/src/gateway_handler/message_parser/parser.rs
+++ b/assyst-core/src/gateway_handler/message_parser/parser.rs
@@ -33,11 +33,9 @@ use crate::ThreadSafeAssyst;
 ///
 /// **Step 4**: Parse the Command from the Message itself. If it fails to parse, prematurely return.
 ///
-/// **Step 5**: Using the parsed Command, identify some metadata conditionals, is the command
-/// age-restricted, allowed in dms, the user has permission to use it, the cooldown
-/// ratelimit isn't exceeded?
-///
 /// Once all steps are complete, a Command is returned, ready for execution.
+/// Note that metadata is checked *during* execution (i.e., in the base command's `Command::execute`
+/// implementation, see [`crate::command::check_metadata`])
 pub async fn parse_message_into_command(
     assyst: ThreadSafeAssyst,
     message: &Message,
@@ -56,9 +54,6 @@ pub async fn parse_message_into_command(
     let Some(command) = find_command_by_name(command) else {
         return Ok(None);
     };
-    let _metadata = command.metadata();
-
-    // TODO: check role permissions, channel permissions, whitelist/blacklist, ...
 
     Ok(Some((command, args, preprocess.prefix)))
 }

--- a/assyst-core/src/gateway_handler/reply.rs
+++ b/assyst-core/src/gateway_handler/reply.rs
@@ -99,7 +99,7 @@ pub async fn edit(ctxt: &CommandCtxt<'_>, builder: MessageBuilder, reply: ReplyI
     Ok(())
 }
 
-async fn create_message(ctxt: &CommandCtxt<'_>, mut builder: MessageBuilder) -> anyhow::Result<()> {
+async fn create_message(ctxt: &CommandCtxt<'_>, builder: MessageBuilder) -> anyhow::Result<()> {
     let allowed_mentions = AllowedMentions::default();
 
     let mut message = ctxt

--- a/assyst-proc-macro/README.md
+++ b/assyst-proc-macro/README.md
@@ -2,6 +2,8 @@
 
 This crate defines proc macros, used primarily by the `assyst-core` crate for its `#[command]` macro.
 
+NOTE: if you're looking to implement a **command group**, use the `assyst_core::command::define_commandgroup!` macro.
+
 ### `#[command]`
 This macro allows you to write bot commands (independent of the source: gateway or interaction) as regular async functions.
 

--- a/assyst-proc-macro/src/lib.rs
+++ b/assyst-proc-macro/src/lib.rs
@@ -33,6 +33,7 @@ impl syn::parse::Parse for CommandAttributes {
 ///
 /// impl Command for remind_command {
 ///     fn execute(&mut self, ctxt: &mut CommandCtxt<'_>) {
+///         check_metadata()?;
 ///         let p1 = Time::parse(ctxt)?;
 ///         let p2 = Rest::parse(ctxt)?;
 ///         remind(p1, p2)
@@ -130,8 +131,14 @@ pub fn command(attrs: TokenStream, func: TokenStream) -> TokenStream {
                 &META
             }
 
+            fn subcommand(&self, _sub: &str) -> Option<crate::command::TCommand> {
+                None
+            }
+
             async fn execute(&self, mut ctxt: crate::command::CommandCtxt<'_>) -> Result<(), crate::command::ExecutionError> {
                 use crate::command::arguments::ParseArgument;
+
+                crate::command::check_metadata(self.metadata(), &mut ctxt).await?;
 
                 #(
                     let #parse_idents = #parse_exprs.map_err(crate::command::ExecutionError::Parse)?;


### PR DESCRIPTION
Also includes some misc things I found on the way.

Notable changes:
- Fast path for valid UTF-8 in `Pipe::read_string`, allowing us to reuse the `Vec<u8>` allocation
- Debug asserts just to save some headache if we ever catch a message being > 4 GB, which would corrupt the pipe
- Box twilight errors because they are very huge (shrinks `TagParseError` from ~170 bytes to 16 bytes)
- Handling subcommands and adjusting the help command
- A `-tag` command group with a `create` subcommand, which currently does nothing